### PR TITLE
Fix deprecation warning of Atom v0.196

### DIFF
--- a/lib/markdown-format.coffee
+++ b/lib/markdown-format.coffee
@@ -2,17 +2,17 @@ markdownfmt = require('./markdownfmt.js')
 
 class MarkdownFormat
   constructor: ->
-    atom.workspace.eachEditor (editor) =>
+    atom.workspace.observeTextEditors (editor) =>
       @handleSave(editor)
 
   destroy: ->
-    atom.unsubscribe()
+    @subscriptions.dispose()
 
   handleSave: (editor) ->
     buffer = editor.getBuffer()
-    atom.subscribe buffer, 'will-be-saved', =>
-      if editor.getGrammar().scopeName is 'source.gfm'
-        buffer.setTextViaDiff(markdownfmt.ProcessMarkdown(buffer.getText()))
+    @subscription = buffer.onWillSave =>
+        if editor.getGrammar().scopeName is 'source.gfm'
+            buffer.setTextViaDiff(markdownfmt.ProcessMarkdown(buffer.getText()))
 
 module.exports =
   activate: ->

--- a/lib/markdown-format.coffee
+++ b/lib/markdown-format.coffee
@@ -6,7 +6,7 @@ class MarkdownFormat
       @handleSave(editor)
 
   destroy: ->
-    @subscriptions.dispose()
+    @subscription.dispose()
 
   handleSave: (editor) ->
     buffer = editor.getBuffer()


### PR DESCRIPTION
Fixed Issue #18 

1. Use Workspace::observeTextEditors instead (Use Workspace::getTextEditors instead)
2. Use TextBuffer::onWillSave instead. A TextBuffer instance is no
longer provided as a callback argument.